### PR TITLE
typo.  s/IndiAuth/IndieAuth/

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cellar-door",
   "version": "1.0.0",
-  "description": "A personal authorization server implementing the IndiAuth federated login protocol.",
+  "description": "A personal authorization server implementing the IndieAuth federated login protocol.",
   "main": "server.js",
   "private": true,
   "scripts": {

--- a/views/partials/layout.hbs
+++ b/views/partials/layout.hbs
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Cellar Door</title>
-    <meta name="description" content="A personal authorization server implementing the IndiAuth federated login protocol.">
+    <meta name="description" content="A personal authorization server implementing the IndieAuth federated login protocol.">
     <link rel="stylesheet" href="/public/style.css">
     <script src="/public/script.js" charset="utf-8"></script>
     <script src="https://button.glitch.me/button.js"></script>
@@ -16,7 +16,7 @@
     <footer class="c-footer u-bg-dark">
       <div class="c-footer__content"><p>
       <a href="https://github.com/nilsnh/cellar-door">Cellar Door</a>,
-      an open-source implementation of the <a href="https://indieweb.org/IndieAuth">IndiAuth</a>
+      an open-source implementation of the <a href="https://indieweb.org/IndieAuth">IndieAuth</a>
       federated login protocol by <a href="https://nilsnh.no">Nils Norman Haukås</a>.
       </p>
       </div>


### PR DESCRIPTION
Simple fix to correct the misspelling of `IndieAuth` in a couple places.